### PR TITLE
implement-expr-id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ find_package(Boost COMPONENTS program_options system filesystem REQUIRED)
 
 set(CMAKE_CXX_STANDARD 11)
 
-bison_target(Parser Lex_Parse/parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.cpp DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/parser.h)
-flex_target(Scanner Lex_Parse/scanner.l ${CMAKE_CURRENT_BINARY_DIR}/scanner.cpp)
+bison_target(Parser Lex_Parse/parser.y ${CMAKE_CURRENT_SOURCE_DIR}/parser.cpp DEFINES_FILE ${CMAKE_CURRENT_SOURCE_DIR}/parser.h)
+flex_target(Scanner Lex_Parse/scanner.l ${CMAKE_CURRENT_SOURCE_DIR}/scanner.cpp)
 add_flex_bison_dependency(Scanner Parser)
 
 include_directories(
-        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/Lex_Parse
         ${CMAKE_CURRENT_SOURCE_DIR}/its_complicated
@@ -40,7 +40,7 @@ source_group("interpreter" FILES ${code_src})
 set(main_srcs Driver.cpp Driver.h)
 source_group("Main" FILES)
 
-#set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(EXTRA_COMPILE_FLAGS "-g -std=c++11")
 

--- a/Driver.cpp
+++ b/Driver.cpp
@@ -43,14 +43,17 @@ int main(int argc, char* argv[]) {
     }
     try {
         int result;
-//        if(argc == 1) {
-            result = driver.parse("/Users/rulonwood/CLionProjects/SummerCompiler/in.cpsl");
-//        }
-//        else {
-//            result = argc == 2? driver.parse(argv[1]) : driver.parse(argv[3]);
-//            std::cout << argc << std::endl;
-//            std::cout << argv[0] << "     " << argv[1] << "     " << argv[2] << "     " << argv[3] << std::endl;
-//        }
+        if(argc == 1) {
+            driver.sourceFile = "/Users/rulonwood/CLionProjects/SummerCompiler/in.cpsl";
+            result = driver.parse(driver.sourceFile);
+        }
+        else {
+
+            driver.sourceFile = argc == 2? argv[1] : argv[3];
+            result = driver.parse(driver.sourceFile);
+            std::cout << argc << std::endl;
+            std::cout << argv[0] << "     " << argv[1] << "     " << argv[2] << "     " << argv[3] << std::endl;
+        }
 
 
         return result;

--- a/Driver.cpp
+++ b/Driver.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
             (argc == 4 && argv[1] != std::string("-o"))/*if 4 args are supplied and the second isn't "-o"...*/||
             argc > 4 /*if there are more than 4 total arguments...*/) {
         std::cout << "ERR: Invalid function call. If you're attempting to invoke the compiler\n"
-                "with a custom output name, Please pair the \"-o\" option with a valid\n"
+                "with a custom output idString, Please pair the \"-o\" option with a valid\n"
                      "number of arguments, followed by the input filename.\n"
                              "Sample:\n\n>>cpslc -o out_file_name.asm cpsl_file_name.cpsl" << std::endl;
         return -1;

--- a/Lex_Parse/parser.y
+++ b/Lex_Parse/parser.y
@@ -162,7 +162,7 @@ OptConstDecls : CONSTSY ConstDecls
 							;
 
 ConstDecls : ConstDecls ConstDecl
-					 | ConstDecl
+					 | ConstDecl {RSWCOMP::ConstBlock();}
 					 ;
 
 ConstDecl : IDENTSY EQSY Expression SCOLONSY {RSWCOMP::declareConst($1, $3);}

--- a/Lex_Parse/scanner.l
+++ b/Lex_Parse/scanner.l
@@ -114,7 +114,7 @@ void Driver::begin_scan() {
     std::string in = "/Users/rulonwood/CLionProjects/SummerCompiler/in.cpsl";
     yy_flex_debug = trace_scanning;
     if(!(yyin = fopen(in.c_str(), "r"))) {
-        error("File name " + sourceFile + " is unable to be opened. strerror: " + strerror(errno));
+        error("File idString " + sourceFile + " is unable to be opened. strerror: " + strerror(errno));
         throw("FILE READ ERROR");
     }
 }

--- a/Lex_Parse/scanner.l
+++ b/Lex_Parse/scanner.l
@@ -111,9 +111,8 @@ write|WRITE         {return yy::Parser::make_WRITESY(loc);}
 
 %%
 void Driver::begin_scan() {
-    std::string in = "/Users/rulonwood/CLionProjects/SummerCompiler/in.cpsl";
     yy_flex_debug = trace_scanning;
-    if(!(yyin = fopen(in.c_str(), "r"))) {
+    if(!(yyin = fopen(sourceFile.c_str(), "r"))) {
         error("File idString " + sourceFile + " is unable to be opened. strerror: " + strerror(errno));
         throw("FILE READ ERROR");
     }

--- a/its_complicated/MetaCoder.h
+++ b/its_complicated/MetaCoder.h
@@ -17,7 +17,6 @@ namespace RSWCOMP {
 
     void MainBlock();
     void ConstBlock();
-    void WriteId(std::string id);
 
     const std::shared_ptr<Expression> CharExpr(char c);
     const std::shared_ptr<Expression> IntExpr(int i);
@@ -36,21 +35,17 @@ namespace RSWCOMP {
     const std::shared_ptr<Expression> OrExpr(std::shared_ptr<Expression> e1, std::shared_ptr<Expression> e2);
     const std::shared_ptr<Expression> NotExpr(std::shared_ptr<Expression> e);
 
-    void WriteVars(Type t);
-
     void declareConst(std::string id, std::shared_ptr<Expression> exp);
-    std::string StringToAsciizData(std::shared_ptr<Expression> exp);
+    std::string ExpToConstData(std::shared_ptr<Expression> exp);
 
     void ReadValue(std::shared_ptr<LValue> lv);
     void WriteExpr(std::shared_ptr<Expression> exp);
     Type SearchForSimple(std::string tString);
+    Type LookupType(std::string tName); //To be implemented...
 
     void Assign(std::shared_ptr<LValue> lv, std::shared_ptr<Expression> exp);
 
     void Stop();
-
-    Type LookupType(std::string tName);
-    void WriteConsts();
 
     std::shared_ptr<Expression> ExprFromLV(std::shared_ptr<LValue> lv);
     std::shared_ptr<LValue> LVFromID(std::string id);
@@ -81,6 +76,7 @@ namespace RSWCOMP {
         int globalOffset =  0;
         int stackOffset = 0;
         int stringCounter = 0;
+        int dataCounter = 0;
 
 
     public:
@@ -96,7 +92,7 @@ namespace RSWCOMP {
         int topOfGlobal(int i){
             //Number of discrete variables involved in user-defined class held in arglist
             int j = globalOffset;
-            globalOffset += (4 * i);
+            globalOffset += i;
             return j;
         }
         static std::shared_ptr<MetaCoder> curr();
@@ -106,6 +102,12 @@ namespace RSWCOMP {
         int nextStringCtr() {
             int ret = stringCounter;
             stringCounter++;
+
+            return ret;
+        }
+        int nextDataCtr() {
+            int ret = dataCounter;
+            dataCounter++;
 
             return ret;
         }

--- a/its_complicated/MetaCoder.h
+++ b/its_complicated/MetaCoder.h
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <its_complicated/components/Expression.h>
 #include <vector>
+#include <sstream>
 #include "its_complicated/components/LValue.h"
 
 namespace RSWCOMP {
@@ -84,19 +85,23 @@ namespace RSWCOMP {
         ~MetaCoder();
         std::ofstream out;
 
+        std::stringstream constBlockToWrite;
+        std::stringstream mainBlockToWrite;
+
         int topOfGlobal() {
             int i = globalOffset;
             globalOffset += 4;
             return i;
         }
         int topOfGlobal(int i){
-            //Number of discrete variables involved in user-defined class held in arglist
+            //Number of discrete variables involved in user-defined class held in arglist * 4
             int j = globalOffset;
             globalOffset += i;
             return j;
         }
         static std::shared_ptr<MetaCoder> curr();
         std::vector<std::string> ids_toWrite;
+        std::vector<std::string> constNamesSeen;
         std::unordered_map<std::string, std::shared_ptr<LValue>> LVs;
         std::unordered_map<std::string, std::shared_ptr<Expression>> constExprs;
         int nextStringCtr() {

--- a/its_complicated/components/Expression.cpp
+++ b/its_complicated/components/Expression.cpp
@@ -19,11 +19,24 @@ namespace RSWCOMP {
         auto curr = MetaCoder::curr();
 
         auto consumed_reg = Register::consumeRegister();
-        exprType = memoryLocation;
-        curr->out << "\tli " << consumed_reg->regName << "," << numericValue << std::endl;
+        if (exprId == "UNSET_ID" || curr->constExprs.find(exprId) == curr->constExprs.end()) {
+            exprType = memoryLocation;
+            curr->mainBlockToWrite << "\tli " << consumed_reg->regName << "," << numericValue << std::endl;
 
-        numericValue = INT32_MIN;
-        return consumed_reg;
+            numericValue = INT32_MIN;
+            return consumed_reg;
+        }
+        else {
+            exprType = memoryLocation;
+            if(containsDataType.t_name == T_STRING) {
+                curr->mainBlockToWrite << "\tmove " << consumed_reg->regName << ", " << exprId << std::endl;
+            }
+            else {
+                curr->mainBlockToWrite << "\tlw " << consumed_reg->regName << "," << exprId << std::endl;
+            }
+            return consumed_reg;
+        }
+
     }
 
     void Expression::intToChar() {

--- a/its_complicated/components/Expression.h
+++ b/its_complicated/components/Expression.h
@@ -24,9 +24,9 @@ namespace RSWCOMP {
         std::string strValue = "DEFAULT_UNSET";
 
     public:
-        inline bool operator==(Expression& lhs, Expression& rhs) {
-            return lhs.getNumericValue() == rhs.getNumericValue()
-                    && lhs.getStrVal() == rhs.getStrVal();
+        inline bool operator==(Expression& rhs) {
+            return this->getNumericValue() == rhs.getNumericValue()
+                    && this->getStrVal() == rhs.getStrVal();
         }
         std::string exprId = "UNSET_ID";
         void intToChar();

--- a/its_complicated/components/Expression.h
+++ b/its_complicated/components/Expression.h
@@ -20,10 +20,15 @@ namespace RSWCOMP {
         ExprDataType exprType;
         std::shared_ptr<RSWCOMP::Register> regLocation = nullptr;
         RSWCOMP::Type containsDataType;
-        int numericValue = 42;
+        int numericValue = INT32_MAX;
         std::string strValue = "DEFAULT_UNSET";
 
     public:
+        inline bool operator==(Expression& lhs, Expression& rhs) {
+            return lhs.getNumericValue() == rhs.getNumericValue()
+                    && lhs.getStrVal() == rhs.getStrVal();
+        }
+        std::string exprId = "UNSET_ID";
         void intToChar();
         void charToInt();
 

--- a/its_complicated/components/LValue.cpp
+++ b/its_complicated/components/LValue.cpp
@@ -3,16 +3,18 @@
 //
 
 #include <iostream>
+#include <algorithm>
 #include "LValue.h"
 #include "its_complicated/MetaCoder.h"
 
 namespace RSWCOMP {
-    std::shared_ptr<LValue> loadId(std::string id) {
+    std::shared_ptr<LValue> loadId(std::string cpsl_id) {
         auto curr = MetaCoder::curr();
-        auto found = curr->LVs.find(id);
+        //TODO: Change below to find-if
+        auto found = curr->LVs.find(cpsl_id);
 
         if (found == curr->LVs.end()) {
-            throw("No variable with provided id exists.");
+            throw("No variable with provided cpsl_id exists.");
         }
         else {
             return found->second;

--- a/its_complicated/components/LValue.h
+++ b/its_complicated/components/LValue.h
@@ -25,10 +25,11 @@ namespace RSWCOMP {
         int globalOffset;
         int stackOffset;
         int constVal;
-        std::string name;
+        std::string idString;
+        std::string cpsl_refname;
     };
 
-    std::shared_ptr<LValue> loadId(std::string id);
+    std::shared_ptr<LValue> loadId(std::string cpsl_id);
 
 }
 


### PR DESCRIPTION
Added several features and project improvements, the most principal of these being the ability to write from a known expression or const without having to define a new const value from a temporary LValue.